### PR TITLE
Implement macOS Submenu `label`, `enabled`

### DIFF
--- a/src/platform_impl/macos/menu_item.rs
+++ b/src/platform_impl/macos/menu_item.rs
@@ -92,7 +92,7 @@ impl TextMenuItem {
 
     pub fn enabled(&self) -> bool {
         unsafe {
-            let enabled: BOOL = msg_send![self.ns_menu_item, enabled];
+            let enabled: BOOL = msg_send![self.ns_menu_item, isEnabled];
             enabled
         }
     }


### PR DESCRIPTION
Enabled state can be toggled through the `NSMenuItem` from the submenu.

If submenu is attached to the menubar, label is affected by `NSMenu`. When the submenu is added inside another submenu, label is affected by `NSMenuItem`.