### PR TITLE
Add `selected` state to `TextMenuItem`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Create the root menu and add submenus and men items.
 let mut menu = Menu::new();
 
 let file_menu = menu.add_submenu("File", true);
-let open_item = file_menu.add_text_item("Open", true);
-let save_item = file_menu.add_text_item("Save", true);
+let open_item = file_menu.add_text_item("Open", true, false);
+let save_item = file_menu.add_text_item("Save", true, false);
 
 let edit_menu = menu.add_submenu("Edit", true);
-let copy_item = file_menu.add_text_item("Copy", true);
-let cut_item = file_menu.add_text_item("Cut", true);
+let copy_item = file_menu.add_text_item("Copy", true, false);
+let cut_item = file_menu.add_text_item("Cut", true, false);
 
 #[cfg(target_os = "windows")]
 menu.init_for_hwnd(window.hwnd() as isize);

--- a/examples/tao.rs
+++ b/examples/tao.rs
@@ -19,13 +19,14 @@ fn main() {
     let mut file_menu = menu_bar.add_submenu("File", true);
     let mut edit_menu = menu_bar.add_submenu("Edit", true);
 
-    let mut open_item = file_menu.add_text_item("Open", true);
+    let mut open_item = file_menu.add_text_item("Open", true, false);
 
-    let mut save_item = file_menu.add_text_item("Save", true);
-    let _quit_item = file_menu.add_text_item("Quit", true);
+    let mut save_item = file_menu.add_text_item("Save", true, false);
+    let _quit_item = file_menu.add_text_item("Quit", true, false);
 
-    let _copy_item = edit_menu.add_text_item("Copy", true);
-    let _cut_item = edit_menu.add_text_item("Cut", true);
+    let mut selected_item = edit_menu.add_text_item("Toggle Selected", true, true);
+    let _copy_item = edit_menu.add_text_item("Copy", true, false);
+    let _cut_item = edit_menu.add_text_item("Cut", true, false);
 
     #[cfg(target_os = "windows")]
     {
@@ -62,6 +63,10 @@ fn main() {
                         open_item.set_enabled(false);
                         open_item_disabled = true;
                     }
+                }
+                _ if event.id == selected_item.id() => {
+                    let selected = selected_item.selected();
+                    selected_item.set_selected(!selected);
                 }
                 _ => {}
             }

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -17,13 +17,14 @@ fn main() {
     let mut file_menu = menu_bar.add_submenu("File", true);
     let mut edit_menu = menu_bar.add_submenu("Edit", true);
 
-    let mut open_item = file_menu.add_text_item("Open", true);
+    let mut open_item = file_menu.add_text_item("Open", true, false);
 
-    let mut save_item = file_menu.add_text_item("Save", true);
-    let _quit_item = file_menu.add_text_item("Quit", true);
+    let mut save_item = file_menu.add_text_item("Save", true, false);
+    let _quit_item = file_menu.add_text_item("Quit", true, false);
 
-    let _copy_item = edit_menu.add_text_item("Copy", true);
-    let _cut_item = edit_menu.add_text_item("Cut", true);
+    let mut selected_item = edit_menu.add_text_item("Toggle Selected", true, true);
+    let _copy_item = edit_menu.add_text_item("Copy", true, false);
+    let _cut_item = edit_menu.add_text_item("Cut", true, false);
 
     #[cfg(target_os = "windows")]
     {
@@ -51,6 +52,10 @@ fn main() {
                         open_item_disabled = true;
                     }
                 }
+                _ if event.id == selected_item.id() => {
+                    let selected = selected_item.selected();
+                    selected_item.set_selected(!selected);
+                }
                 _ => {}
             }
         }
@@ -59,7 +64,7 @@ fn main() {
             #[cfg(target_os = "macos")]
             Event::NewEvents(winit::event::StartCause::Init) => {
                 menu_bar.init_for_nsapp();
-            },
+            }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 ..

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,8 +159,13 @@ impl Submenu {
     }
 
     /// Creates a new [`TextMenuItem`] whithin this submenu.
-    pub fn add_text_item(&mut self, label: impl AsRef<str>, enabled: bool) -> TextMenuItem {
-        TextMenuItem(self.0.add_text_item(label, enabled))
+    pub fn add_text_item(
+        &mut self,
+        label: impl AsRef<str>,
+        enabled: bool,
+        selected: bool,
+    ) -> TextMenuItem {
+        TextMenuItem(self.0.add_text_item(label, enabled, selected))
     }
 }
 
@@ -187,6 +192,16 @@ impl TextMenuItem {
     /// Enables or disables the menu item.
     pub fn set_enabled(&mut self, enabled: bool) {
         self.0.set_enabled(enabled)
+    }
+
+    /// Gets the menu item's current selected state.
+    pub fn selected(&self) -> bool {
+        self.0.selected()
+    }
+
+    /// Select or unselect the menu item.
+    pub fn set_selected(&mut self, selected: bool) {
+        self.0.set_selected(selected)
     }
 
     /// Gets the unique id for this menu item.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,12 +22,12 @@
 //! let mut menu = Menu::new();
 //!
 //! let file_menu = menu.add_submenu("File", true);
-//! let open_item = file_menu.add_text_item("Open", true);
-//! let save_item = file_menu.add_text_item("Save", true);
+//! let open_item = file_menu.add_text_item("Open", true, false);
+//! let save_item = file_menu.add_text_item("Save", true, false);
 //!
 //! let edit_menu = menu.add_submenu("Edit", true);
-//! let copy_item = file_menu.add_text_item("Copy", true);
-//! let cut_item = file_menu.add_text_item("Cut", true);
+//! let copy_item = file_menu.add_text_item("Copy", true, false);
+//! let cut_item = file_menu.add_text_item("Cut", true, false);
 //! ```
 //!
 //! # Add your root menu to a Window (Windows and Linux Only)

--- a/src/platform_impl/linux.rs
+++ b/src/platform_impl/linux.rs
@@ -146,7 +146,12 @@ impl Submenu {
         Submenu(entry)
     }
 
-    pub fn add_text_item(&mut self, label: impl AsRef<str>, enabled: bool) -> TextMenuItem {
+    pub fn add_text_item(
+        &mut self,
+        label: impl AsRef<str>,
+        enabled: bool,
+        selected: bool,
+    ) -> TextMenuItem {
         let entry = Arc::new(Mutex::new(MenuEntry {
             label: label.as_ref().to_string(),
             enabled,
@@ -188,6 +193,14 @@ impl TextMenuItem {
             item.set_sensitive(enabled);
         }
         entry.enabled = enabled;
+    }
+
+    pub fn selected(&self) -> bool {
+        todo!()
+    }
+
+    pub fn set_selected(&self, is_selected: bool) {
+        todo!()
     }
 
     pub fn id(&self) -> u64 {

--- a/src/platform_impl/macos/menu_item.rs
+++ b/src/platform_impl/macos/menu_item.rs
@@ -58,7 +58,7 @@ pub struct TextMenuItem {
 }
 
 impl TextMenuItem {
-    pub fn new(label: impl AsRef<str>, enabled: bool, selector: Sel) -> Self {
+    pub fn new(label: impl AsRef<str>, enabled: bool, selected: bool, selector: Sel) -> Self {
         let (id, ns_menu_item) = make_menu_item(label.as_ref(), selector);
 
         unsafe {
@@ -67,6 +67,10 @@ impl TextMenuItem {
 
             if !enabled {
                 let () = msg_send![ns_menu_item, setEnabled: NO];
+            }
+
+            if selected {
+                let () = msg_send![ns_menu_item, setState: 1_isize];
             }
         }
 
@@ -104,6 +108,23 @@ impl TextMenuItem {
                 false => NO,
             };
             let () = msg_send![self.ns_menu_item, setEnabled: status];
+        }
+    }
+
+    pub fn selected(&self) -> bool {
+        unsafe {
+            let selected: BOOL = msg_send![self.ns_menu_item, state];
+            selected
+        }
+    }
+
+    pub fn set_selected(&self, is_selected: bool) {
+        let state = match is_selected {
+            true => 1_isize,
+            false => 0_isize,
+        };
+        unsafe {
+            let () = msg_send![self.ns_menu_item, setState: state];
         }
     }
 

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -23,11 +23,7 @@ impl Menu {
 
     pub fn add_submenu(&mut self, label: impl AsRef<str>, enabled: bool) -> Submenu {
         let menu = Menu::new();
-        let menu_item = TextMenuItem::new(
-            "",
-            enabled,
-            sel!(fireMenubarAction:),
-        );
+        let menu_item = TextMenuItem::new("", enabled, false, sel!(fireMenubarAction:));
 
         unsafe {
             menu_item.ns_menu_item.setSubmenu_(menu.0);
@@ -78,8 +74,13 @@ impl Submenu {
         self.menu.add_submenu(label, enabled)
     }
 
-    pub fn add_text_item(&mut self, label: impl AsRef<str>, enabled: bool) -> TextMenuItem {
-        let item = TextMenuItem::new(label, enabled, sel!(fireMenubarAction:));
+    pub fn add_text_item(
+        &mut self,
+        label: impl AsRef<str>,
+        enabled: bool,
+        selected: bool,
+    ) -> TextMenuItem {
+        let item = TextMenuItem::new(label, enabled, selected, sel!(fireMenubarAction:));
         unsafe {
             self.menu.0.addItem_(item.ns_menu_item);
         }

--- a/src/platform_impl/windows.rs
+++ b/src/platform_impl/windows.rs
@@ -124,7 +124,12 @@ impl Submenu {
         }
     }
 
-    pub fn add_text_item(&mut self, label: impl AsRef<str>, enabled: bool) -> TextMenuItem {
+    pub fn add_text_item(
+        &mut self,
+        label: impl AsRef<str>,
+        enabled: bool,
+        selected: bool,
+    ) -> TextMenuItem {
         let id = COUNTER.next();
         let mut flags = MF_POPUP;
         if !enabled {
@@ -201,6 +206,14 @@ impl TextMenuItem {
                 if enabled { MF_ENABLED } else { MF_DISABLED },
             )
         };
+    }
+
+    pub fn selected(&self) -> bool {
+        todo!()
+    }
+
+    pub fn set_selected(&self, is_selected: bool) {
+        todo!()
     }
 
     pub fn id(&self) -> u64 {


### PR DESCRIPTION
Added selected methods to the `TextMenuItem` interface and  modified some examples.

I've only implemented it in macOS , so I leave todo!() in windows and unix's impl.